### PR TITLE
Data type 2209 has been added and the type of "type_id" or "DATA_TYPE" has been corrected

### DIFF
--- a/include/ibeo_lux/ibeo_lux_common.h
+++ b/include/ibeo_lux/ibeo_lux_common.h
@@ -24,6 +24,9 @@
 #include <ibeo_msgs/ScanPoint2205.h>
 #include <ibeo_msgs/ScannerInfo2205.h>
 #include <ibeo_msgs/ScanData2205.h>
+#include <ibeo_msgs/ScanPoint2209.h>
+#include <ibeo_msgs/ScannerInfo2209.h>
+#include <ibeo_msgs/ScanData2209.h>
 #include <ibeo_msgs/Object2221.h>
 #include <ibeo_msgs/ObjectData2221.h>
 #include <ibeo_msgs/Object2225.h>

--- a/include/ibeo_lux/ibeo_lux_ros_msg_handler.h
+++ b/include/ibeo_lux/ibeo_lux_ros_msg_handler.h
@@ -24,7 +24,7 @@ namespace IbeoLux
 class IbeoLuxRosMsgHandler
 {
 public:
-  void fillAndPublish(const uint8_t& type_id,
+  void fillAndPublish(const uint16_t& type_id,
                       const std::string& frame_id,
                       const ros::Publisher& pub,
                       IbeoTxMessage * parser_class);
@@ -61,6 +61,10 @@ private:
   void fill2205(
     IbeoTxMessage * parser_class,
     ibeo_msgs::ScanData2205 * new_msg,
+    const std::string& frame_id);
+  void fill2209(
+    IbeoTxMessage * parser_class,
+    ibeo_msgs::ScanData2209 * new_msg,
     const std::string& frame_id);
   void fill2221(
     IbeoTxMessage * parser_class,

--- a/src/ros_ibeo_lux.cpp
+++ b/src/ros_ibeo_lux.cpp
@@ -89,6 +89,7 @@ int main(int argc, char **argv)
   ros::Publisher scan_data_pub, object_data_pub, vehicle_state_pub, error_warn_pub;
   ros::Publisher fusion_scan_2204_pub,
     fusion_scan_2205_pub,
+    fusion_scan_2209_pub,
     fusion_object_2225_pub,
     fusion_object_2280_pub,
     fusion_img_2403_pub,
@@ -112,6 +113,7 @@ int main(int argc, char **argv)
   {
     fusion_scan_2204_pub = n.advertise<ibeo_msgs::ScanData2204>("parsed_tx/scan_data_2204", 1);
     fusion_scan_2205_pub = n.advertise<ibeo_msgs::ScanData2205>("parsed_tx/scan_data_2205", 1);
+    fusion_scan_2209_pub = n.advertise<ibeo_msgs::ScanData2209>("parsed_tx/scan_data_2209", 1);
     fusion_object_2225_pub = n.advertise<ibeo_msgs::ObjectData2225>("parsed_tx/object_data_2225", 1);
     fusion_object_2280_pub = n.advertise<ibeo_msgs::ObjectData2280>("parsed_tx/object_data_2280", 1);
     fusion_img_2403_pub = n.advertise<ibeo_msgs::CameraImage>("parsed_tx/camera_image", 1);
@@ -120,6 +122,7 @@ int main(int argc, char **argv)
 
     pub_list.insert(std::make_pair(ScanData2204::DATA_TYPE, fusion_scan_2204_pub));
     pub_list.insert(std::make_pair(ScanData2205::DATA_TYPE, fusion_scan_2205_pub));
+    pub_list.insert(std::make_pair(ScanData2209::DATA_TYPE, fusion_scan_2209_pub));
     pub_list.insert(std::make_pair(ObjectData2225::DATA_TYPE, fusion_object_2225_pub));
     pub_list.insert(std::make_pair(ObjectData2280::DATA_TYPE, fusion_object_2280_pub));
     pub_list.insert(std::make_pair(CameraImage::DATA_TYPE, fusion_img_2403_pub));


### PR DESCRIPTION
Data type 2209 is sent by the new firmware version of the Fusion ECU (2019-R1_v8.0.0).

Uint8_t will cause an overflow.